### PR TITLE
Refine frontend styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Curate Frontend</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,30 +42,31 @@ export default function App() {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
-      <div className="max-w-6xl mx-auto py-10 px-4">
+    <div className="min-h-screen bg-gray-50 text-gray-800">
+      <div className="max-w-6xl mx-auto py-12 px-4">
         <div className="flex justify-between items-center mb-8 animate-fade-in">
           <div>
-            <h1 className="text-4xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+            <h1 className="flex items-center text-4xl font-semibold text-gray-900 tracking-tight">
               Curate
+              <span className="ml-2 inline-block h-3 w-3 rounded-full bg-indigo-500"></span>
             </h1>
             <div className="flex items-center mt-2 text-gray-600">
               <span>AI-Powered Dataset Training</span>
               <span className="mx-2">•</span>
               <span className="flex items-center gap-2">
-                Backend: 
+                Backend:
                 <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${
-                  status === 'healthy' 
-                    ? 'bg-green-100 text-green-800' 
-                    : status === 'loading' 
-                    ? 'bg-yellow-100 text-yellow-800' 
+                  status === 'healthy'
+                    ? 'bg-green-100 text-green-800'
+                    : status === 'loading'
+                    ? 'bg-yellow-100 text-yellow-800'
                     : 'bg-red-100 text-red-800'
                 }`}>
                   <div className={`w-2 h-2 rounded-full ${
-                    status === 'healthy' 
-                      ? 'bg-green-500 animate-pulse' 
-                      : status === 'loading' 
-                      ? 'bg-yellow-500 animate-pulse' 
+                    status === 'healthy'
+                      ? 'bg-green-500 animate-pulse'
+                      : status === 'loading'
+                      ? 'bg-yellow-500 animate-pulse'
                       : 'bg-red-500'
                   }`}></div>
                   {status}
@@ -73,7 +74,7 @@ export default function App() {
               </span>
             </div>
           </div>
-          
+
           {(showChat || activeTab !== "upload") && (
             <button
               onClick={handleNewUpload}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,12 @@
 
 /* Custom Styles */
 
+body {
+  font-family: "Inter", system-ui, sans-serif;
+  color: #1f2937;
+  background-color: #f9fafb;
+}
+
 /* Smooth scrolling */
 html {
   scroll-behavior: smooth;
@@ -49,18 +55,18 @@ html {
 
 /* Custom button styles */
 .btn-primary {
-  background: linear-gradient(135deg, #3b82f6, #2563eb);
+  background-color: #4f46e5;
   color: white;
   padding: 0.75rem 1.5rem;
   border-radius: 0.5rem;
   font-weight: 500;
-  transition: all 0.2s;
+  transition: background-color 0.2s, transform 0.2s;
   transform: scale(1);
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  background-color: #4338ca;
   transform: scale(1.05);
 }
 
@@ -108,15 +114,15 @@ html {
 .card-hover {
   background: white;
   border-radius: 0.75rem;
-  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   padding: 1.5rem;
-  border: 1px solid #f3f4f6;
-  transition: all 0.3s;
+  border: 1px solid #e5e7eb;
+  transition: box-shadow 0.2s, transform 0.2s;
 }
 
 .card-hover:hover {
-  box-shadow: 0 0 20px rgba(59, 130, 246, 0.15);
-  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
 }
 
 /* Custom input styles */


### PR DESCRIPTION
## Summary
- adopt neutral layout and accent title for a cleaner minimal aesthetic
- simplify button and card styling for subtle pop
- load Inter font globally for consistent typography

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ef45d5b08832690ab2a85730e9c89